### PR TITLE
(linkwarden) fix: Storage, SSO and generic Helm template related fixes

### DIFF
--- a/charts/linkwarden/Chart.yaml
+++ b/charts/linkwarden/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 2.5.3
 kubeVersion: ">=1.26"
 name: linkwarden
-version: 0.2.0
+version: 0.2.1
 dependencies:
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/linkwarden/templates/configmap.yaml
+++ b/charts/linkwarden/templates/configmap.yaml
@@ -16,7 +16,17 @@ metadata:
 data:
   NEXTAUTH_URL: {{ (include "linkwarden.ingress.url" .) | quote }}
   PAGINATION_TAKE_COUNT: {{ .Values.linkwarden.paginationTakeCount | quote }}
+  {{- if eq .Values.linkwarden.data.storageType "filesystem" }}
   STORAGE_FOLDER: {{ include "linkwarden.paths.data" . | quote }}
+  {{- end }}
+  {{- if eq .Values.linkwarden.data.storageType "s3" }}
+  SPACES_ENDPOINT: {{ .Values.linkwarden.data.s3.endpoint }}
+  SPACES_REGION: {{ .Values.linkwarden.data.s3.region }}
+  {{- if eq .Values.linkwarden.data.s3.forcePathStyle true }}
+  SPACES_FORCE_PATH_STYLE: "true"
+  {{- end }}
+  SPACES_BUCKET_NAME: {{ .Values.linkwarden.data.s3.bucketName }}
+  {{- end }}
   AUTOSCROLL_TIMEOUT: {{ .Values.linkwarden.autoscrollTimeout | quote }}
   RE_ARCHIVE_LIMIT: {{ .Values.linkwarden.rearchiveLimit | quote }}
   {{- if .Values.linkwarden.maxFileSize }}
@@ -42,7 +52,7 @@ data:
 {{- $providerArg := (dict "provider" $v.provider) }}
 {{- $provider := $v.provider }}
 {{- $issuer := $v.issuer }}
-{{- $issuerList := include "linkwarden.auth.providers.withIssuers" . | fromJsonArray }}
+{{- $issuerList := include "linkwarden.auth.providers.withIssuers" $ | fromJsonArray }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -51,12 +61,12 @@ metadata:
   labels:
     app.kubernetes.io/component: linkwarden
     {{- include "linkwarden.labels" $ | nindent 4 }}
-    {{- if .Values.configMap.labels }}
-    {{- toYaml .Values.configMap.labels | nindent 4 }}
+    {{- if $.Values.configMap.labels }}
+    {{- toYaml $.Values.configMap.labels | nindent 4 }}
     {{- end }}
-  {{- if .Values.configMap.annotations }}
+  {{- if $.Values.configMap.annotations }}
   annotations:
-  {{- toYaml .Values.configMap.annotations | nindent 4 }}
+  {{- toYaml $.Values.configMap.annotations | nindent 4 }}
   {{- end }}
 data:
   {{ include "linkwarden.auth.envs.nextPublicEnable" $providerArg }}: "true"

--- a/charts/linkwarden/templates/deployment.yaml
+++ b/charts/linkwarden/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "linkwarden.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.linkwarden.replicas }}
   selector:
     matchLabels:
       {{- include "linkwarden.selectorLabels" . | nindent 6 }}

--- a/charts/linkwarden/templates/deployment.yaml
+++ b/charts/linkwarden/templates/deployment.yaml
@@ -96,8 +96,10 @@ spec:
               containerPort: 3000
               protocol: TCP
           volumeMounts:
+          {{- if eq .Values.linkwarden.data.storageType "filesystem" }}
             - name: {{ include "linkwarden.pv.name" . }}
               mountPath: {{ include "linkwarden.paths.data" .  }}
+          {{- end }}
           {{- if .Values.volumeMounts }}
             {{- toYaml .Values.volumeMounts | nindent 12 }}
           {{- end }}

--- a/charts/linkwarden/templates/secrets.yaml
+++ b/charts/linkwarden/templates/secrets.yaml
@@ -82,13 +82,13 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     app.kubernetes.io/component: linkwarden
-    {{- include "linkwarden.labels" . | nindent 4 }}
-    {{- if .Values.secret.labels }}
-    {{- toYaml .Values.secret.labels | nindent 4 }}
+    {{- include "linkwarden.labels" $ | nindent 4 }}
+    {{- if $.Values.secret.labels }}
+    {{- toYaml $.Values.secret.labels | nindent 4 }}
     {{- end }}
-  {{- if .Values.secret.annotations }}
+  {{- if $.Values.secret.annotations }}
   annotations:
-    {{- toYaml .Values.secret.annotations | nindent 4 -}}
+    {{- toYaml $.Values.secret.annotations | nindent 4 -}}
   {{- end }}
 type: Opaque
 data:

--- a/charts/linkwarden/values.schema.json
+++ b/charts/linkwarden/values.schema.json
@@ -51,6 +51,11 @@
         "linkwarden": {
             "type": "object",
             "properties": {
+                "replicas": {
+                    "type": "number",
+                    "description": "The number of Linkwarden replicas (pods) to deploy",
+                    "default": 1
+                },
                 "domain": {
                     "type": "string",
                     "description": "The domain name to assign to Linkwarden, to be re-used as the NextAuth URL and",

--- a/charts/linkwarden/values.yaml
+++ b/charts/linkwarden/values.yaml
@@ -53,6 +53,10 @@ fullnameOverride: ""
 ## ref: https://github.com/dani-garcia/linkwarden/wiki/Configuration-overview
 
 linkwarden:
+  ## @param linkwarden.replicas [number] The number of Linkwarden replicas (pods) to deploy
+  ##
+  replicas: 1
+
   ## @param linkwarden.domain [string] The domain name to assign to Linkwarden, to be re-used as the NextAuth URL and
   ## as the 'host' entry within the Ingress configuration
   ##


### PR DESCRIPTION
<!--
Thank you for contributing to fmjstudios/helm.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fmjstudios/helm/blob/main/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable MD041 -->

#### What this PR does / why we need it

When storage type is set to S3 the PVC is not being created (correct) but referenced (incorrect) as a volume mount. Furhter there were missing S3 related variables and additional helm template issues.
This PR stops all the abote that from happending.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `(paperless-ngx)`)
