### PR TITLE
(paperless-ngx) fix(charts/paperless-ngx): Fix Redis External Secret

### DIFF
--- a/charts/paperless-ngx/Chart.yaml
+++ b/charts/paperless-ngx/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 2.10.1
 kubeVersion: ">=1.26"
 name: paperless-ngx
-version: 0.2.0
+version: 0.2.1
 dependencies:
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/paperless-ngx/templates/_secrets.tpl
+++ b/charts/paperless-ngx/templates/_secrets.tpl
@@ -26,21 +26,6 @@ Set the names of the secrets
 {{- end }}
 
 {{/*
-Build connection URI's
-*/}}
-{{- define "paperless.redis.password" -}}
-{{- if .Values.paperless.redis.existingSecret }}
-{{- printf "%s" ((lookup "v1" "Secret" .Release.Namespace (.Values.paperless.redis.existingSecret)).data.password) }}
-{{- else }}
-{{- printf "%s" .Values.paperless.redis.password }}
-{{- end }}
-{{- end }}
-
-{{- define "paperless.redis.uri" -}}
-{{- printf "redis://%s:%s@%s:%d" .Values.paperless.redis.username (include "paperless.redis.password" .) .Values.paperless.redis.host (int .Values.paperless.redis.port) }}
-{{- end }}
-
-{{/*
   Detect or generate a secret key for the installation
 */}}
 {{- define "paperless.secretkey" -}}

--- a/charts/paperless-ngx/templates/secrets.yaml
+++ b/charts/paperless-ngx/templates/secrets.yaml
@@ -68,7 +68,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  uri: {{ include "paperless.redis.uri" . | b64enc | quote }}
+  password: {{ .Values.paperless.redis.password | b64enc | quote }}
 {{- end }}
 ---
 {{- /*

--- a/charts/paperless-ngx/templates/statefulset.yaml
+++ b/charts/paperless-ngx/templates/statefulset.yaml
@@ -45,11 +45,19 @@ spec:
             - configMapRef:
                 name: {{ include "paperless.configmaps.general" . }}
           env:
-            - name: PAPERLESS_REDIS
+            - name: paperless_redis_host
+              value: {{ .Values.paperless.redis.host }}
+            - name: paperless_redis_port
+              value: {{ .Values.paperless.redis.port | quote }}
+            - name: paperless_redis_username
+              value: {{ default "" .Values.paperless.redis.username }}
+            - name: paperless_redis_password
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "paperless.secrets.redis" . }}
-                  key: uri
+                  name: {{ default (include "paperless.secrets.redis" .) .Values.paperless.redis.existingSecret }}
+                  key: password
+            - name: PAPERLESS_REDIS
+              value: "redis://$(paperless_redis_username):$(paperless_redis_password)@$(paperless_redis_host):$(paperless_redis_port)"
             - name: PAPERLESS_DBUSER
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
env PAPERLESS_REDIS was always referencing a specific secret which was never built when usind an externalSecret for Redis, rendering paperless.redis.existingSecret useless, although there was some code to create an URI out of the existing secret.
Now the URI is constructed by using dependent ENV variables.

<!--
Thank you for contributing to fmjstudios/helm.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fmjstudios/helm/blob/main/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable MD041 -->

#### Which issue this PR fixes

- fixes #8 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `(paperless-ngx)`)
