### PR TITLE
fix(charts/paperless-ngx): tika and gotenberg endpoints

### DIFF
--- a/.github/AUTHORS
+++ b/.github/AUTHORS
@@ -10,3 +10,4 @@ FMJ Studios
 Maximilian Gindorfer <info@fmj.dev>
 STRGZRS
 kehralexander <alexanderkehr@alexware.systems>
+fty4

--- a/charts/paperless-ngx/Chart.yaml
+++ b/charts/paperless-ngx/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 2.10.1
 kubeVersion: ">=1.26.0-0"
 name: paperless-ngx
-version: 0.2.3
+version: 0.2.4
 dependencies:
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/paperless-ngx/templates/_secrets.tpl
+++ b/charts/paperless-ngx/templates/_secrets.tpl
@@ -48,6 +48,22 @@ Build connection URI's
 {{- printf "redis://%s:%s@%s:%d" .Values.paperless.redis.username .Values.paperless.redis.password (include "paperless.redis.host" .) (int .Values.paperless.redis.port) }}
 {{- end }}
 
+{{- define "paperless.tika.endpoint" -}}
+{{- if .Values.paperless.tika.endpoint -}}
+{{- printf "%s" .Values.paperless.tika.endpoint }}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name "tika" }}
+{{- end -}}
+{{- end }}
+
+{{- define "paperless.gotenberg.endpoint" -}}
+{{- if .Values.paperless.gotenberg.endpoint -}}
+{{- printf "%s" .Values.paperless.gotenberg.endpoint }}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name "gotenberg" }}
+{{- end -}}
+{{- end }}
+
 {{/*
   Detect or generate a secret key for the installation
 */}}

--- a/charts/paperless-ngx/templates/_secrets.tpl
+++ b/charts/paperless-ngx/templates/_secrets.tpl
@@ -56,12 +56,20 @@ Build connection URI's
 {{- end -}}
 {{- end }}
 
+{{- define "paperless.tika.uri" -}}
+{{- printf "http://%s:%d" (include "paperless.tika.endpoint" .) 9998 }}
+{{- end }}
+
 {{- define "paperless.gotenberg.endpoint" -}}
 {{- if .Values.paperless.gotenberg.endpoint -}}
 {{- printf "%s" .Values.paperless.gotenberg.endpoint }}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name "gotenberg" }}
 {{- end -}}
+{{- end }}
+
+{{- define "paperless.gotenberg.uri" -}}
+{{- printf "http://%s:%d" (include "paperless.gotenberg.endpoint" .) 80 }}
 {{- end }}
 
 {{/*

--- a/charts/paperless-ngx/templates/configmap.yaml
+++ b/charts/paperless-ngx/templates/configmap.yaml
@@ -193,11 +193,11 @@ data:
   {{- if .Values.paperless.tika.enabled }}
   PAPERLESS_TIKA_ENABLED: {{ .Values.paperless.tika.enabled | quote }}
   PAPERLESS_TIKA_ENDPOINT: {{ (include "paperless.tika.endpoint" .) | quote }}
-  {{- end }}
   {{- /*
     Gotenberg configuration
   */}}
   PAPERLESS_TIKA_GOTENBERG_ENDPOINT: {{ (include "paperless.gotenberg.endpoint" .) | quote }}
+  {{- end }}
   {{- /*
     SMTP configuration
   */}}

--- a/charts/paperless-ngx/templates/configmap.yaml
+++ b/charts/paperless-ngx/templates/configmap.yaml
@@ -192,11 +192,11 @@ data:
   */}}
   {{- if .Values.paperless.tika.enabled }}
   PAPERLESS_TIKA_ENABLED: {{ .Values.paperless.tika.enabled | quote }}
-  PAPERLESS_TIKA_ENDPOINT: {{ (include "paperless.tika.endpoint" .) | quote }}
+  PAPERLESS_TIKA_ENDPOINT: {{ (include "paperless.tika.uri" .) | quote }}
   {{- /*
     Gotenberg configuration
   */}}
-  PAPERLESS_TIKA_GOTENBERG_ENDPOINT: {{ (include "paperless.gotenberg.endpoint" .) | quote }}
+  PAPERLESS_TIKA_GOTENBERG_ENDPOINT: {{ (include "paperless.gotenberg.uri" .) | quote }}
   {{- end }}
   {{- /*
     SMTP configuration

--- a/charts/paperless-ngx/templates/configmap.yaml
+++ b/charts/paperless-ngx/templates/configmap.yaml
@@ -192,12 +192,12 @@ data:
   */}}
   {{- if .Values.paperless.tika.enabled }}
   PAPERLESS_TIKA_ENABLED: {{ .Values.paperless.tika.enabled | quote }}
-  PAPERLESS_TIKA_ENDPOINT: {{ .Values.paperless.tika.endpoint | quote }}
+  PAPERLESS_TIKA_ENDPOINT: {{ (include "paperless.tika.endpoint" .) | quote }}
   {{- end }}
   {{- /*
     Gotenberg configuration
   */}}
-  PAPERLESS_TIKA_GOTENBERG_ENDPOINT: {{ .Values.paperless.gotenberg.endpoint | quote }}
+  PAPERLESS_TIKA_GOTENBERG_ENDPOINT: {{ (include "paperless.gotenberg.endpoint" .) | quote }}
   {{- /*
     SMTP configuration
   */}}


### PR DESCRIPTION
<!--
Thank you for contributing to fmjstudios/helm.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fmjstudios/helm/blob/main/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast(er) feedback, please @-mention maintainers that are listed in the Chart.yaml file. Please note we cannot ensure
a fast response time and as such you are at the mercy of said maintainers time constraints.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly. Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable MD041 -->

Hello @FMJdev thank you for this repo / chart - I have some issue with the tika and gothenberg endpoints.

#### What this PR does / why we need it

The tika and gotenberg templated ENV variables are empty by default because it uses a empty values configuration:

https://github.com/fmjstudios/helm/blob/fea914b264718488c3104292280c9d705bf1c3a1/charts/paperless-ngx/templates/configmap.yaml#L190-L200

https://github.com/fmjstudios/helm/blob/fea914b264718488c3104292280c9d705bf1c3a1/charts/paperless-ngx/values.yaml#L329-L344

The new environment variables for the endpoints _(k8s service)_ will be generated as e.g. follows:

```diff
<   PAPERLESS_TIKA_ENDPOINT: ""
<   PAPERLESS_TIKA_GOTENBERG_ENDPOINT: ""
---
>   PAPERLESS_TIKA_ENDPOINT: "http://paperless-ngx-tika:9998"
>   PAPERLESS_TIKA_GOTENBERG_ENDPOINT: "http://paperless-ngx-gotenberg:80"
```


#### Which issue this PR fixes

no issue opened

#### Special notes for your reviewer

This implementation adds two new functions to the helpers for each endpoint.
If desired they can be merged into one - I added two because it was more likely to fit in the other helper functions.

Also currently the uri can not be overwritten by the values file - only the endpoint which will always add `http://` and the port (`9998`/`80`) to the environment variable.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart Version bumped
- [x] User name added to [`AUTHORS`](AUTHORS) file
- [x] Title of the PR starts with a valid commit scope as detailed in the [CONTRIBUTING](../docs/CONTRIBUTING.md) (e.g.
      `fix(charts/linkwarden): ...`)
