### PR TITLE
fix(charts/linkwarden): add missing env to disable registration

### DIFF
--- a/charts/linkwarden/Chart.yaml
+++ b/charts/linkwarden/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: 2.5.3
 kubeVersion: ">=1.26.0-0"
 name: linkwarden
-version: 0.3.3
+version: 0.3.4
 dependencies:
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts
@@ -51,5 +51,5 @@ annotations:
   org.opencontainers.image.licenses: "MIT"
   # ref: https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
-    - kind: removed
-      description: convert 'existingSecret' from object to string and fixed key to 'uri'
+    - kind: fixed
+      description: add missing env to disable registration

--- a/charts/linkwarden/templates/configmap.yaml
+++ b/charts/linkwarden/templates/configmap.yaml
@@ -29,6 +29,9 @@ data:
   {{- end }}
   AUTOSCROLL_TIMEOUT: {{ .Values.linkwarden.autoscrollTimeout | quote }}
   RE_ARCHIVE_LIMIT: {{ .Values.linkwarden.rearchiveLimit | quote }}
+  {{- if .Values.linkwarden.auth.disableRegistration }}
+  NEXT_PUBLIC_DISABLE_REGISTRATION: {{ .Values.linkwarden.auth.disableRegistration | quote }}
+  {{- end }}
   {{- if .Values.linkwarden.maxFileSize }}
   NEXT_PUBLIC_MAX_FILE_SIZE: {{ .Values.linkwarden.maxFileSize | quote }}
   {{- end }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

#### What this PR does / why we need it

Add missing environment variable `NEXT_PUBLIC_DISABLE_REGISTRATION` to allow to disable user registration.
The configuration value already exists but does not change anything regarding the templating.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart Version bumped
- [x] User name added to [`AUTHORS`](AUTHORS) file
- [x] Title of the PR starts with a valid commit scope as detailed in the [CONTRIBUTING](../docs/CONTRIBUTING.md) (e.g.
      `fix(charts/linkwarden): ...`)
