### PR TITLE
chore(charts/linkwarden): use appVersion instead tag / image update v2.8.3

### DIFF
--- a/charts/linkwarden/Chart.yaml
+++ b/charts/linkwarden/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: v2.8.3
 kubeVersion: ">=1.26.0-0"
 name: linkwarden
-version: 0.3.3
+version: 0.3.5
 dependencies:
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts
@@ -51,5 +51,7 @@ annotations:
   org.opencontainers.image.licenses: "MIT"
   # ref: https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
-    - kind: removed
-      description: convert 'existingSecret' from object to string and fixed key to 'uri'
+    - kind: changed
+      description: using appVersion to determ image tag
+    - kind: changed
+      description: update linkwarden to v2.8.3

--- a/charts/linkwarden/Chart.yaml
+++ b/charts/linkwarden/Chart.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 apiVersion: v2
-appVersion: 2.5.3
+appVersion: v2.8.3
 kubeVersion: ">=1.26.0-0"
 name: linkwarden
 version: 0.3.3

--- a/charts/linkwarden/values.yaml
+++ b/charts/linkwarden/values.yaml
@@ -19,7 +19,7 @@
 image:
   registry: ghcr.io
   repository: linkwarden/linkwarden
-  tag: "v2.5.3"
+  tag: ""
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

#### What this PR does / why we need it

I'd love to see if instead of the [`image.tag`](https://github.com/fmjstudios/helm/blob/ac8dccf55930fdfa6b350ed441643d1d3c44aa85/charts/linkwarden/values.yaml#L22) the [`appVersion`](https://github.com/fmjstudios/helm/blob/ac8dccf55930fdfa6b350ed441643d1d3c44aa85/charts/linkwarden/Chart.yaml#L5) is used to set the application version of the chart.

Therefore I removed the tag-value content to use the default.
This also required to add the `v` prefix to the appVersion.

Another change is to update to the latest linkwarden image [`v2.8.3`](https://github.com/linkwarden/linkwarden/releases/tag/v2.8.3).

#### Special notes for your reviewer

I hope you also like that stlye - otherwise feel free to close this PR.

_Updated chart version to 0.3.**5** to ensure faster merging after #26._

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart Version bumped
- [x] User name added to [`AUTHORS`](AUTHORS) file
- [x] Title of the PR starts with a valid commit scope as detailed in the [CONTRIBUTING](../docs/CONTRIBUTING.md) (e.g.
      `fix(charts/linkwarden): ...`)
