### PR TITLE
fix(charts/linkwarden): adding existingSecret in auth.sso list does not prevent new secret from being created

### DIFF
--- a/charts/linkwarden/templates/secrets.yaml
+++ b/charts/linkwarden/templates/secrets.yaml
@@ -75,6 +75,7 @@ data:
   Authentication secrets
 */}}
 {{- range $_, $v := .Values.linkwarden.auth.sso }}
+{{- if not $v.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -100,4 +101,5 @@ data:
   tenantId: {{ $v.tenantId | b64enc | quote }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to fmjstudios/helm.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fmjstudios/helm/blob/main/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast(er) feedback, please @-mention maintainers that are listed in the Chart.yaml file. Please note we cannot ensure
a fast response time and as such you are at the mercy of said maintainers time constraints.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly. Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable MD041 -->

#### What this PR does / why we need it

Currently in the Linkwarden chart, when setting `.Values.linkwarden.auth.sso[*].existingSecret`, the chart still attempts to create the auth secret for that given provider. Beyond that there is an error when `clientId` and `clientSecret` are not set, leading to your values file requiring at least an empty value for both when using an existing secret.

#### Special notes for your reviewer

We could probably bundle this in with #33 - I've left the Chart version untouched for that reason. If you'd rather this be a separate version bump I can add the change

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart Version bumped
- [ ] User name added to [`AUTHORS`](AUTHORS) file
- [x] Title of the PR starts with a valid commit scope as detailed in the [CONTRIBUTING](../docs/CONTRIBUTING.md) (e.g.
      `fix(charts/linkwarden): ...`)
