### PR TITLE
fix(charts/linkwarden): Add volumeName to pvc

### DIFF
--- a/charts/linkwarden/templates/pvc.yaml
+++ b/charts/linkwarden/templates/pvc.yaml
@@ -19,4 +19,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.linkwarden.data.filesystem.pvc.size }}
+  {{- if .Values.linkwarden.data.filesystem.pvc.volumeName }}
+  volumeName: {{ .Values.linkwarden.data.filesystem.pvc.volumeName }}
+  {{- end }}
 {{- end }}

--- a/charts/linkwarden/values.yaml
+++ b/charts/linkwarden/values.yaml
@@ -129,6 +129,9 @@ linkwarden:
         ## @param linkwarden.data.filesystem.pvc.reclaimPolicy [default: Retain] The resourcePolicy given to PVCs
         ##
         reclaimPolicy: Retain
+        ## @param linkwarden.data.filesystem.pvc.volumeName [string] The volumeName given to PVCs
+        ##
+        volumeName: ""
         ## @param linkwarden.data.filesystem.pvc.existingClaim [string] Provide the name to an existing PVC
         ##
         existingClaim: ""


### PR DESCRIPTION
#### What this PR does / why we need it

This commit add [volumeName](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-name) parameter to pvc.

#### Which issue this PR fixes

-

#### Special notes for your reviewer

#### Checklist

- [x] Title of the PR starts with a valid commit scope as detailed in the [CONTRIBUTING](../docs/CONTRIBUTING.md) (e.g.
      `fix(charts/linkwarden): ...`)
