### PR TITLE
fix(charts/linkwarden): fix secretkey ref default value

### DIFF
--- a/charts/linkwarden/templates/deployment.yaml
+++ b/charts/linkwarden/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ default .Values.linkwarden.database.existingSecret (include "linkwarden.secrets.db" .) }}
+                  name: {{ default (include "linkwarden.secrets.db" .) .Values.linkwarden.database.existingSecret }}
                   key: uri
             {{- end }}
             {{/* Authentication settings */}}


### PR DESCRIPTION
#### What this PR does / why we need it

Fix database url name ref if existingSecret is used. ([swap `default` func parameters](https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-default-function))

#### Which issue this PR fixes

-

#### Special notes for your reviewer

#### Checklist

- [x] Title of the PR starts with a valid commit scope as detailed in the [CONTRIBUTING](../docs/CONTRIBUTING.md) (e.g.
      `fix(charts/linkwarden): ...`)
