### PR TITLE
fix(charts/linkwarden): Storage folder env sould relative path

### DIFF
--- a/charts/linkwarden/templates/configmap.yaml
+++ b/charts/linkwarden/templates/configmap.yaml
@@ -17,7 +17,7 @@ data:
   NEXTAUTH_URL: {{ (include "linkwarden.ingress.url" .) | quote }}
   PAGINATION_TAKE_COUNT: {{ .Values.linkwarden.paginationTakeCount | quote }}
   {{- if eq .Values.linkwarden.data.storageType "filesystem" }}
-  STORAGE_FOLDER: {{ include "linkwarden.paths.data" . | quote }}
+  STORAGE_FOLDER: {{ .Values.linkwarden.data.filesystem.dataPath | quote }}
   {{- end }}
   {{- if eq .Values.linkwarden.data.storageType "s3" }}
   SPACES_ENDPOINT: {{ .Values.linkwarden.data.s3.endpoint }}


### PR DESCRIPTION
#### What this PR does / why we need it

Storage path env variable sould be relative path, because linkwarden make the full absolute path:
https://github.com/linkwarden/linkwarden/blob/main/lib/api/storage/createFolder.ts#L10

#### Which issue this PR fixes

-

#### Special notes for your reviewer

#### Checklist

- [x] Title of the PR starts with a valid commit scope as detailed in the [CONTRIBUTING](../docs/CONTRIBUTING.md) (e.g.
      `fix(charts/linkwarden): ...`)
