### PR TITLE
Existing secret for linkwarden.database always fallsback to helper.tpl value

### DIFF
--- a/charts/linkwarden/templates/deployment.yaml
+++ b/charts/linkwarden/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ default .Values.linkwarden.database.existingSecret (include "linkwarden.secrets.db" .) }}
+                  name: {{ if .Values.linkwarden.database.existingSecret }}{{ .Values.linkwarden.database.existingSecret }}{{ else }}{{ include "linkwarden.secrets.db" . }}{{ end }}
                   key: uri
             {{- end }}
             {{/* Authentication settings */}}


### PR DESCRIPTION
#### What this PR does / why we need it

This PR updates the Helm chart’s deployment template to respect a user-provided existingSecret for the database URI, falling back to the auto-generated secret name only if none is specified

#### Special notes for your reviewer

- The change is backward-compatible: if no `existingSecret` is provided, the chart behaves as before
